### PR TITLE
Feature/update reqs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,10 +8,10 @@ author = "Timothy Brathwaite"
 author-email = "timothyb0912@gmail.com"
 home-page = "https://github.com/timothyb0912/checkrs"
 requires = [
+    "future",
     "matplotlib",
     "numpy",
     "pandas",
-    "past",
     "pkg_resources",
     "scipy",
     "seaborn",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ requires = [
     "matplotlib",
     "numpy",
     "pandas",
-    "pkg_resources",
     "scipy",
     "seaborn",
     "sklearn",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires = [
     "pandas",
     "scipy",
     "seaborn",
-    "sklearn",
+    "scikit-learn",
     "statsmodels",
     "tqdm",
 ]

--- a/requirements.in
+++ b/requirements.in
@@ -1,8 +1,10 @@
+altair
 attrs
 black
 bump2version
 flake8
 flit
+future
 gitchangelog
 graphviz
 interrogate
@@ -10,6 +12,8 @@ jupyter
 jupytext
 pandas
 pip-tools
+pipdeptree
+pipreqs
 pre-commit
 pydeps
 pydocstyle

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@
 #    pip-compile requirements.in
 #
 alabaster==0.7.12         # via sphinx
+altair==4.1.0             # via -r requirements.in
 appdirs==1.4.4            # via black, virtualenv
 appnope==0.1.0            # via ipykernel, ipython
 argon2-cffi==20.1.0       # via notebook
@@ -34,14 +35,15 @@ decorator==4.4.2          # via ipython, networkx
 defusedxml==0.6.0         # via nbconvert
 distlib==0.3.1            # via virtualenv
 django==3.1.1             # via pyscaffold
+docopt==0.6.2             # via pipreqs
 docutils==0.16            # via flit, recommonmark, sphinx
-entrypoints==0.3          # via nbconvert
+entrypoints==0.3          # via altair, nbconvert
 filelock==3.0.12          # via virtualenv
 flake8-polyfill==1.0.2    # via radon
 flake8==3.8.3             # via -r requirements.in, flake8-polyfill
 flit-core==3.0.0          # via flit
 flit==3.0.0               # via -r requirements.in
-future==0.18.2            # via pylogit, radon
+future==0.18.2            # via -r requirements.in, pylogit, radon
 gitchangelog==3.0.4       # via -r requirements.in
 graphviz==0.14.1          # via -r requirements.in
 identify==1.5.5           # via pre-commit
@@ -57,9 +59,9 @@ ipython==7.18.1           # via ipykernel, ipywidgets, jupyter-console, watermar
 ipywidgets==7.5.1         # via jupyter
 jedi==0.17.2              # via ipython
 jinja2-time==0.2.0        # via cookiecutter
-jinja2==2.11.2            # via cookiecutter, jinja2-time, nbconvert, notebook, sphinx
+jinja2==2.11.2            # via altair, cookiecutter, jinja2-time, nbconvert, notebook, sphinx
 joblib==0.16.0            # via scikit-learn
-jsonschema==3.2.0         # via nbformat
+jsonschema==3.2.0         # via altair, nbformat
 jupyter-client==6.1.7     # via ipykernel, jupyter-console, nbclient, notebook, qtconsole
 jupyter-console==6.2.0    # via jupyter
 jupyter-core==4.6.3       # via jupyter-client, nbconvert, nbformat, notebook, qtconsole
@@ -83,9 +85,9 @@ networkx==2.5             # via importlab
 ninja==1.10.0.post2       # via pytype
 nodeenv==1.5.0            # via pre-commit
 notebook==6.1.4           # via jupyter, widgetsnbextension
-numpy==1.19.2             # via matplotlib, pandas, patsy, pylogit, scikit-learn, scipy, seaborn, statsmodels
+numpy==1.19.2             # via altair, matplotlib, pandas, patsy, pylogit, scikit-learn, scipy, seaborn, statsmodels
 packaging==20.4           # via bleach, pytest, sphinx
-pandas==1.1.2             # via -r requirements.in, pylogit, seaborn, statsmodels
+pandas==1.1.2             # via -r requirements.in, altair, pylogit, seaborn, statsmodels
 pandocfilters==1.4.2      # via nbconvert
 parso==0.7.1              # via jedi
 pathspec==0.8.0           # via black
@@ -94,6 +96,8 @@ pexpect==4.8.0            # via ipython
 pickleshare==0.7.5        # via ipython
 pillow==7.2.0             # via matplotlib
 pip-tools==5.3.1          # via -r requirements.in
+pipdeptree==1.0.0         # via -r requirements.in
+pipreqs==0.4.10           # via -r requirements.in
 pluggy==0.13.1            # via pytest
 poyo==0.5.0               # via cookiecutter
 pre-commit==2.7.1         # via -r requirements.in
@@ -132,7 +136,7 @@ radon[flake8]==4.3.2      # via xenon
 recommonmark==0.6.0       # via pyscaffoldext-markdown
 regex==2020.7.14          # via black
 reorder-python-imports==2.3.5  # via -r requirements.in
-requests==2.24.0          # via cookiecutter, flit, sphinx, xenon
+requests==2.24.0          # via cookiecutter, flit, sphinx, xenon, yarg
 scikit-learn==0.23.2      # via -r requirements.in
 scipy==1.5.2              # via pylogit, scikit-learn, seaborn, statsmodels
 seaborn==0.11.0           # via -r requirements.in
@@ -155,6 +159,7 @@ testpath==0.4.4           # via nbconvert
 text-unidecode==1.3       # via python-slugify
 threadpoolctl==2.1.0      # via scikit-learn
 toml==0.10.1              # via black, interrogate, jupytext, pre-commit, pytest
+toolz==0.11.1             # via altair
 tornado==6.0.4            # via ipykernel, jupyter-client, notebook, terminado
 tqdm==4.49.0              # via -r requirements.in, pylogit
 traitlets==5.0.4          # via ipykernel, ipython, ipywidgets, jupyter-client, jupyter-core, nbclient, nbconvert, nbformat, notebook, qtconsole
@@ -168,6 +173,7 @@ webencodings==0.5.1       # via bleach
 wheel==0.35.1             # via pyscaffoldext-markdown
 widgetsnbextension==3.5.1  # via ipywidgets
 xenon==0.7.1              # via -r requirements.in
+yarg==0.1.9               # via pipreqs
 zipp==3.2.0               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
# What
This PR addresses issue #8. It makes the following changes to the package requirements in pyproject.toml:
- "past" -> "future"
- "sklearn" -> "scikit-learn"
- removes "pkg_resources" 

It also adds development requirements:
- `pipreqs` for tracking project dependencies
- `pipdeptree` for visualizing project dependencies, similar to `pydeps`
- `altair` as a visualization library to be tested as a replacement for `matplotlib`.